### PR TITLE
Handle zero-or-more multi-value fields correctly. [#1172956]

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -21,6 +21,10 @@ $editable_fields = array(
   'employeeType', 'bugzillaEmail', 'shirtsize', 'b2gNumber', 'roomNumber', 'githubProfile'
 );
 
+$deleteable_fields = array(
+  'emailAlias', 'mobile', 'im',
+);
+
 $office_cities = array(
     'Mountain View' => 'US', 
     'San Francisco' => 'US',

--- a/edit.php
+++ b/edit.php
@@ -87,6 +87,15 @@ if (!empty($_POST)) {
     $memcache->delete(MEMCACHE_PREFIX . $edit_user . 'standard');
     $memcache->delete(MEMCACHE_PREFIX . $edit_user . 'thumb');
   }
+  // The user may have cleared the 'zero or more' fields on the edit.php page.
+  // That means their POST won't contain any values for those fields. So we
+  // explicitly check for their absence and force them to an empty array here,
+  // which instructs ldap_modify() to delete all items, as the user intended.
+  foreach ($deleteable_fields as $attribute) {
+    if (!isset($new_user_data[$attribute])) {
+      $new_user_data[$attribute] = array();
+    }
+  }
   if (ldap_modify($ldapconn,
                   $auth->email_to_dn($ldapconn, $edit_user),
                   $new_user_data)) {


### PR DESCRIPTION
Turns out we need this alongside mozilla/phonebook#38 after all, so merging for test/deploy, again.
