### PR TITLE
Remove all uses of inline styles [#1305110]

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -718,3 +718,7 @@ body.lightbox #overlay {
     text-align: center;
     margin-top: 5em;
 }
+
+.pgpfingerprintfont {
+    font-size: 12px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -713,3 +713,8 @@ div.photo-frame {
 body.lightbox #overlay {
   display: block;
   }
+
+.ohnoes {
+    text-align: center;
+    margin-top: 5em;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -722,3 +722,10 @@ body.lightbox #overlay {
 .pgpfingerprintfont {
     font-size: 12px;
 }
+
+.office-city-display-hide {
+    display: none;
+}
+.office-city-display-show {
+    display: block;
+}

--- a/js/common.js
+++ b/js/common.js
@@ -260,7 +260,7 @@ String.prototype.dnToEmail = function dnToEmail() {
 };
 
 SearchManager.notFoundMessage =
-  '<div style="text-align: center; margin-top: 5em;">' +
+  '<div class="ohnoes">' +
     '<img src="./img/ohnoes.jpg" />' +
     '<h2>OH NOES! No ones were foundz.</h2>' +
   '</div>';

--- a/output-html.inc
+++ b/output-html.inc
@@ -3,9 +3,9 @@
 
 function output_pgpFingerprint($s) {
   $stripped_fingerprint = str_replace(" ", "", $s);
-  $inner_text = '<a target="_blank" style="font-size: 12px;" href="http://gpg.mozilla.org/pks/lookup?search=0x' . $stripped_fingerprint . '&op=vindex">' . $stripped_fingerprint . '</a>';
+  $inner_text = '<a target="_blank" class="pgpfingerprintfont" href="http://gpg.mozilla.org/pks/lookup?search=0x' . $stripped_fingerprint . '&op=vindex">' . $stripped_fingerprint . '</a>';
   $return_string = '<div class="pgpfingerprint">';
-  $return_string .= 'PGP Fingerprint: <span style="font-size: 12px;">' . $inner_text . '</span>';
+  $return_string .= 'PGP Fingerprint: <span class="pgpfingerprintfont">' . $inner_text . '</span>';
   $return_string .= '</div>';
   return $return_string;
 }

--- a/templates/edit.php
+++ b/templates/edit.php
@@ -35,7 +35,7 @@ if (!empty($city) && !in_array($city, array_keys($office_cities))) {
 ?>
     <td id='office-cities'>
 <?php
-$office_city_display_style = "display: none;";
+$office_city_display_style = "hide";
 $primary_country = '';
 $counter = 0;
 $other_city_name = '';
@@ -56,7 +56,7 @@ $other_city_name = '';
           $oc = escape($oc);
           $octry = escape($octry);
           if (!in_array($city, array_keys($office_cities)) && $oc == "Other"){
-            $office_city_display_style = "display: block;";
+            $office_city_display_style = "show";
             $other_city_name = $city;
             echo "<option value=\"$oc\" data-country=\"{$octry}\" selected=\"selected\">$oc</option>";
           } else {
@@ -70,7 +70,7 @@ $other_city_name = '';
 $counter++;
 } ?>
     <a id="office-add" href="#">Add Office</a><br />
-      <input id="office-city-text" style="<?php echo $office_city_display_style ?>" type="text" name="office_city_name" value="<?php echo escape($other_city_name) ?>" />
+      <input id="office-city-text" class="office-city-display-<?php echo $office_city_display_style ?>" type="text" name="office_city_name" value="<?php echo escape($other_city_name) ?>" />
     </td>
   </tr>
 


### PR DESCRIPTION
These commits remove all known instances of inline styles from Phonebook, so that we can remove the CSP property `style-src: unsafe-inline`.
